### PR TITLE
書籍一覧の表示タイプを切り替えれるように

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -63,3 +63,10 @@ body {
   'GRAD' 0,
   'opsz' 24
 }
+
+.two-lines {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,14 @@
 "use client"
 
 import { books } from '../books'
-import BookCard from "@/components/book_card";
+import BookListView from "@/components/book_list_view";
 
 export default function Home() {
   return (
     <div>
       <main>
-        <h2 className='m-3 text-3xl font-bold'>書籍一覧</h2>
-        <div className="auto-rows-fr gap-x-4 gap-y-6 grid grid-cols-4 m-3">
-          {books.map((book, index) => (
-            <div key={index} className='flex flex-col'>
-              <BookCard book={book}></BookCard>
-            </div>
-          ))}
-        </div>
+        <h2 className='mb-3 text-3xl font-bold'>書籍一覧</h2>
+        <BookListView books={books}></BookListView>
       </main>
     </div>
   );

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 import { books } from '../../books'
 import { useState } from 'react';
-import BookCard from "@/components/book_card";
 import searchBooks, { BookList } from "./search";
+import BookListView from "@/components/book_list_view";
 
 export default function Home() {
   const [bookTitle, setBookTitle] = useState('');
@@ -22,9 +22,7 @@ export default function Home() {
   return (
     <div>
       <main>
-        <h2 className='m-3 text-3xl font-bold'>さがす</h2>
-        <div className="m-3">
-
+        <h2 className='mb-3 text-3xl font-bold'>さがす</h2>
         <form onSubmit={(e) => e.preventDefault()}>
           <div className="relative">
               <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
@@ -36,25 +34,19 @@ export default function Home() {
               <button onClick={handleClick} type="submit" className="transition duration-150 ease-linear text-white absolute right-2.5 bottom-2.5 bg-accent hover:bg-accent-bright outline-none font-medium rounded-lg text-sm px-4 py-2">検索</button>
           </div>
         </form>
-
-        </div>
         {matchbooks.length === 0 &&
-          <div className='m-3'>
+          <div className='my-3'>
             書籍が見つかりませんでした。
           </div>
         }
         {!firstShowPage && matchbooks.length !== 0 &&
-          <div className='m-3'>
+          <div className='my-3'>
             {matchbooks.length}点の書籍が見つかりました。
           </div>
         }
-        <div className="auto-rows-fr gap-2.5 grid grid-cols-4 m-3">
+        <div>
           {!firstShowPage &&
-            matchbooks.map((book, index) => (
-              <div key={index} className='flex flex-col'>
-                <BookCard book={book}></BookCard>
-              </div>
-            ))
+            <BookListView books={matchbooks}></BookListView>
           }
         </div>
       </main>

--- a/src/components/book_card.tsx
+++ b/src/components/book_card.tsx
@@ -18,7 +18,7 @@ export default function BookCard({book}: {book: Book}) {
       />
       <div className='flex flex-col p-2'>
         <Tooltip text={book.name}>
-          <h3 className='font-semibold text-ellipsis two-lines mb-2'>{book.name}</h3>
+          <h3 className='font-semibold break-all text-ellipsis two-lines mb-2'>{book.name}</h3>
         </Tooltip>
       </div>
     </div>

--- a/src/components/book_card.tsx
+++ b/src/components/book_card.tsx
@@ -1,28 +1,25 @@
 import Image from 'next/image'
 import { basePath } from '../../next.config'
 import { Book } from "@/types/book";
-import Tooltip from "@/components/tooltip";
 import path from "path";
+import Tooltip from "./tooltip";
 
 const BASE_PATH = basePath ? basePath : '';
 
 export default function BookCard({book}: {book: Book}) {
   return (
-    <div className='rounded-xl border py-3 px-6'>
-      <Tooltip text={book.name}>
-        <h3 className='text-xl font-semibold whitespace-nowrap truncate mb-2'>{book.name}</h3>
-      </Tooltip>
+    <div className='rounded-lg border border-neutral-300 flex flex-col'>
       <Image
-        className='mx-auto rounded-lg'
+        className='rounded-t-lg w-full'
         src={path.join(BASE_PATH, book.image)}
         alt='noImage'
-        width={300}
-        height={400}
+        width={250}
+        height={250}
       />
-      <div className='flex flex-col mt-2'>
-        <p>ISBN : {book.isbn}</p>
-        <p>出版 : {book.publication}</p>
-        <p>著者 : {book.author}</p>
+      <div className='flex flex-col p-2'>
+        <Tooltip text={book.name}>
+          <h3 className='font-semibold text-ellipsis two-lines mb-2'>{book.name}</h3>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/components/book_detail.tsx
+++ b/src/components/book_detail.tsx
@@ -1,0 +1,26 @@
+import Image from 'next/image'
+import { basePath } from '../../next.config'
+import { Book } from "@/types/book";
+import path from "path";
+
+const BASE_PATH = basePath ? basePath : '';
+
+export default function BookDetail({book}: {book: Book}) {
+  return (
+    <div className="bg-white rounded-lg border flex flex-row">
+      <Image
+        className='rounded-l-lg h-full'
+        src={path.join(BASE_PATH, book.image)}
+        alt='noImage'
+        width={300}
+        height={300}
+      />
+      <div className='flex flex-col py-2 pl-4 pr-8 w-80'>
+        <h3 className='font-semibold text-ellipsis two-lines mb-2'>{book.name}</h3>
+        <p>ISBN : {book.isbn}</p>
+        <p>出版 : {book.publication}</p>
+        <p>著者 : {book.author}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/book_detail.tsx
+++ b/src/components/book_detail.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import { basePath } from '../../next.config'
 import { Book } from "@/types/book";
 import path from "path";
+import Tooltip from "./tooltip";
 
 const BASE_PATH = basePath ? basePath : '';
 
@@ -16,7 +17,9 @@ export default function BookDetail({book}: {book: Book}) {
         height={300}
       />
       <div className='flex flex-col py-2 pl-4 pr-8 w-80'>
-        <h3 className='font-semibold text-ellipsis two-lines mb-2'>{book.name}</h3>
+        <Tooltip text={book.name}>
+          <h3 className='font-semibold text-ellipsis two-lines mb-2'>{book.name}</h3>
+        </Tooltip>
         <p>ISBN : {book.isbn}</p>
         <p>出版 : {book.publication}</p>
         <p>著者 : {book.author}</p>

--- a/src/components/book_list_item.tsx
+++ b/src/components/book_list_item.tsx
@@ -1,0 +1,26 @@
+import Image from 'next/image'
+import { basePath } from '../../next.config'
+import { Book } from "@/types/book";
+import path from "path";
+
+const BASE_PATH = basePath ? basePath : '';
+
+export default function BookListItem({book}: {book: Book}) {
+  return (
+    <div className='rounded-lg border border-neutral-300 flex flex-row justify-start gap-2'>
+      <Image
+        className='rounded-l-lg'
+        src={path.join(BASE_PATH, book.image)}
+        alt='noImage'
+        width={100}
+        height={150}
+      />
+      <div className='flex flex-col py-2'>
+        <h3 className='font-semibold mb-2'>{book.name}</h3>
+        <p>ISBN : {book.isbn}</p>
+        <p>出版 : {book.publication}</p>
+        <p>著者 : {book.author}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/book_list_view.tsx
+++ b/src/components/book_list_view.tsx
@@ -1,0 +1,52 @@
+import { Book } from "@/types/book";
+import { useState } from "react";
+import BookListItem from "@/components/book_list_item";
+import BookDetail from "@/components/book_detail";
+import BookCard from "@/components/book_card";
+
+export default function BookListView({books}: {books: Book[]}) {
+  const [viewType, setViewType] = useState("grid"); 
+  const [selectedBookIndex, setSelectedBookIndex] = useState(-1);
+
+  const listViewIcon = <span className="material-symbols-outlined" onClick={() => setViewType("list")}>list</span>
+  const gridViewIcon = <span className="material-symbols-outlined" onClick={() => setViewType("grid")}>grid_view</span>
+
+  return (
+    <>
+      <div className="mb-3 w-full flex flex-row-reverse  gap-x-4 cursor-pointer">
+          {listViewIcon}
+          {gridViewIcon}
+        </div>
+        {viewType === "grid" ? 
+          <div className="grid grid-cols-6 gap-x-4 gap-y-4 items-stretch">
+            {books.map((book, index) => (
+              <div onClick={() => setSelectedBookIndex(index)} key={index} className="flex items-stretch cursor-pointer">
+                <BookCard book={book}></BookCard>
+              </div>
+            ))}
+          </div>
+        :
+          <div className="flex flex-col gap-y-4">
+            {books.map((book, index) => (
+              <div onClick={() => setSelectedBookIndex(index)} key={index} className="cursor-pointer">
+                <BookListItem book={book}></BookListItem>
+              </div>
+            ))}
+          </div>
+        }
+        { selectedBookIndex >= 0 && selectedBookIndex < books.length &&
+          <div className="w-screen h-screen fixed top-0 left-0">
+              <div className="w-full h-full opacity-50 bg-black"></div>
+              <div className="w-full h-full absolute top-0 left-0 flex justify-center items-center">
+                <div className="flex gap-2">
+                  <BookDetail book={books[selectedBookIndex]}></BookDetail>
+                  <span onClick={() => setSelectedBookIndex(-1)} className="cursor-pointer text-white material-symbols-outlined">
+                    close
+                  </span>
+                </div>
+              </div>
+          </div>
+        }
+    </>
+  );
+}

--- a/src/components/book_list_view.tsx
+++ b/src/components/book_list_view.tsx
@@ -18,7 +18,11 @@ export default function BookListView({books}: {books: Book[]}) {
           {gridViewIcon}
         </div>
         {viewType === "grid" ? 
-          <div className="grid grid-cols-6 gap-x-4 gap-y-4 items-stretch">
+          <div className="grid gap-x-4 gap-y-4 items-stretch
+            xl:grid-cols-6
+            lg:grid-cols-4
+            grid-cols-3
+            ">
             {books.map((book, index) => (
               <div onClick={() => setSelectedBookIndex(index)} key={index} className="flex items-stretch cursor-pointer">
                 <BookCard book={book}></BookCard>


### PR DESCRIPTION
# やったこと

- グリッドビューの列数を4から６にした
- グリッドビューのときはタイトルのみを表示するように
- グリッドビューのタイトルは2行だけ表示（入りきらない分は省略）
- リストビューを追加
- リストビューでは著者やISBNが表示される
- グリッドビューでもリストビューでも本をクリックすると詳細がポップアップされる
- 書籍一覧をコンポーネント化し「さがす」タブでも同じように表示できるようにした

## グリッドビュー
![image](https://github.com/kazu51-gh/cac-library/assets/19502796/4657fdf3-c3e2-4dac-9e56-c02dbeba9a73)

## リストビュー
![image](https://github.com/kazu51-gh/cac-library/assets/19502796/d6367ef6-a6f4-4248-8350-43b025282689)

## 詳細表示
![image](https://github.com/kazu51-gh/cac-library/assets/19502796/1ce1d1b1-0ce5-4657-b5b0-5e3be5213012)
